### PR TITLE
Remove slack webhook protection

### DIFF
--- a/src/main/kotlin/com/carbonara/core/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/carbonara/core/security/SecurityConfig.kt
@@ -21,6 +21,7 @@ class SecurityConfig {
             .authorizeExchange { exchanges ->
                 exchanges
                     .pathMatchers("/mollie-payment-status").permitAll()
+                    .pathMatchers("/slack-delivery-status").permitAll()
                     .anyExchange().authenticated()
             }
             .oauth2ResourceServer { oauth2 ->


### PR DESCRIPTION
- Whitelist slack webhook in security config