### PR TITLE
Remove workflow dispatch from github actions

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
Deploy staging can only be triggered when merging PR